### PR TITLE
support sw_entry multi jsonPath and docs_entry multi specPath

### DIFF
--- a/entry/docs_entry.go
+++ b/entry/docs_entry.go
@@ -49,11 +49,11 @@ type spec struct {
 // 3: SpecPath: The path of where swagger or open API spec file was located.
 // 4: Headers: The headers that would be added into each API response.
 type BootDocs struct {
-	Enabled  bool     `yaml:"enabled" json:"enabled"`
-	Path     string   `yaml:"path" json:"path"`
-	SpecPath string   `yaml:"specPath" json:"specPath"`
-	Headers  []string `yaml:"headers" json:"headers"`
-	Style    struct {
+	Enabled   bool     `yaml:"enabled" json:"enabled"`
+	Path      string   `yaml:"path" json:"path"`
+	SpecPaths []string `yaml:"specPaths" json:"specPaths"`
+	Headers   []string `yaml:"headers" json:"headers"`
+	Style     struct {
 		Theme string `yaml:"theme" json:"theme"`
 	} `yaml:"style" json:"style"`
 	Debug bool `yaml:"debug" json:"debug"`
@@ -64,7 +64,7 @@ type DocsEntry struct {
 	entryName        string            `json:"-" yaml:"-"`
 	entryType        string            `json:"-" yaml:"-"`
 	entryDescription string            `json:"-" yaml:"-"`
-	SpecPath         string            `json:"-" yaml:"-"`
+	SpecPaths        []string          `json:"-" yaml:"-"`
 	Path             string            `json:"-" yaml:"-"`
 	Headers          map[string]string `json:"-" yaml:"-"`
 	Debug            bool              `yaml:"-" json:"-"`
@@ -101,7 +101,7 @@ func RegisterDocsEntry(boot *BootDocs, opts ...DocsEntryOption) *DocsEntry {
 			entryType:        DocsEntryType,
 			entryDescription: "Internal RK entry for documentation UI.",
 			Path:             boot.Path,
-			SpecPath:         boot.SpecPath,
+			SpecPaths:        boot.SpecPaths,
 			Headers:          headers,
 		}
 
@@ -169,7 +169,7 @@ func (entry *DocsEntry) MarshalJSON() ([]byte, error) {
 		"name":        entry.GetName(),
 		"type":        entry.GetType(),
 		"description": entry.GetDescription(),
-		"specPath":    entry.SpecPath,
+		"specPaths":   entry.SpecPaths,
 		"path":        entry.Path,
 		"Headers":     entry.Headers,
 		"debug":       entry.Debug,
@@ -244,9 +244,11 @@ func (entry *DocsEntry) initDocsConfig() {
 		Specs: []*spec{},
 	}
 
-	if len(entry.SpecPath) > 0 {
+	if len(entry.SpecPaths) > 0 {
 		// 1: Add user API swagger JSON
-		entry.listFilesWithSuffix(config, entry.SpecPath, false)
+		for _, specPath := range entry.SpecPaths {
+			entry.listFilesWithSuffix(config, specPath, false)
+		}
 	} else {
 		// try to read from default directories
 		// - docs

--- a/entry/docs_entry_test.go
+++ b/entry/docs_entry_test.go
@@ -15,14 +15,14 @@ import (
 
 func TestRegisterDocsEntry(t *testing.T) {
 	entry := RegisterDocsEntry(&BootDocs{
-		Enabled:  true,
-		Path:     "ut-path",
-		SpecPath: "ut-spec-path",
-		Headers:  []string{"a:b"},
+		Enabled:   true,
+		Path:      "ut-path",
+		SpecPaths: []string{"ut-spec-path"},
+		Headers:   []string{"a:b"},
 	})
 
 	assert.Equal(t, "/ut-path/", entry.Path)
-	assert.Equal(t, "ut-spec-path", entry.SpecPath)
+	assert.Equal(t, []string{"ut-spec-path"}, entry.SpecPaths)
 	assert.Len(t, entry.Headers, 1)
 	assert.NotEmpty(t, entry.GetName())
 	assert.NotEmpty(t, entry.GetType())
@@ -34,10 +34,10 @@ func TestDocsEntry_Bootstrap_Interrupt(t *testing.T) {
 	defer assertNotPanic(t)
 
 	entry := RegisterDocsEntry(&BootDocs{
-		Enabled:  true,
-		Path:     "ut-path",
-		SpecPath: "ut-spec-path",
-		Headers:  []string{"a:b"},
+		Enabled:   true,
+		Path:      "ut-path",
+		SpecPaths: []string{"ut-spec-path"},
+		Headers:   []string{"a:b"},
 	})
 
 	entry.Bootstrap(context.TODO())
@@ -46,10 +46,10 @@ func TestDocsEntry_Bootstrap_Interrupt(t *testing.T) {
 
 func TestDocsEntry_UnmarshalJSON(t *testing.T) {
 	entry := RegisterDocsEntry(&BootDocs{
-		Enabled:  true,
-		Path:     "ut-path",
-		SpecPath: "ut-spec-path",
-		Headers:  []string{"a:b"},
+		Enabled:   true,
+		Path:      "ut-path",
+		SpecPaths: []string{"ut-spec-path"},
+		Headers:   []string{"a:b"},
 	})
 	assert.Nil(t, entry.UnmarshalJSON(nil))
 }
@@ -57,10 +57,10 @@ func TestDocsEntry_UnmarshalJSON(t *testing.T) {
 func TestDocsEntry_ConfigFileHandler(t *testing.T) {
 	defer assertNotPanic(t)
 	entry := RegisterDocsEntry(&BootDocs{
-		Enabled:  true,
-		Path:     "ut-path",
-		SpecPath: "ut-spec-path",
-		Headers:  []string{"a:b"},
+		Enabled:   true,
+		Path:      "ut-path",
+		SpecPaths: []string{"ut-spec-path"},
+		Headers:   []string{"a:b"},
 	})
 
 	writer := httptest.NewRecorder()

--- a/entry/sw_entry.go
+++ b/entry/sw_entry.go
@@ -43,10 +43,10 @@ type swUrl struct {
 // 3: JsonPath: The path of where swagger JSON file was located.
 // 4: Headers: The headers that would added into each API response.
 type BootSW struct {
-	Enabled  bool     `yaml:"enabled" json:"enabled"`
-	Path     string   `yaml:"path" json:"path"`
-	JsonPath string   `yaml:"jsonPath" json:"jsonPath"`
-	Headers  []string `yaml:"headers" json:"headers"`
+	Enabled   bool     `yaml:"enabled" json:"enabled"`
+	Path      string   `yaml:"path" json:"path"`
+	JsonPaths []string `yaml:"jsonPaths" json:"jsonPaths"`
+	Headers   []string `yaml:"headers" json:"headers"`
 }
 
 // SWEntry implements rke.Entry interface.
@@ -54,7 +54,7 @@ type SWEntry struct {
 	entryName        string            `json:"-" yaml:"-"`
 	entryType        string            `json:"-" yaml:"-"`
 	entryDescription string            `json:"-" yaml:"-"`
-	JsonPath         string            `json:"-" yaml:"-"`
+	JsonPaths        []string          `json:"-" yaml:"-"`
 	Path             string            `json:"-" yaml:"-"`
 	Headers          map[string]string `json:"-" yaml:"-"`
 	embedFS          *embed.FS         `json:"-" yaml:"-"`
@@ -86,7 +86,7 @@ func RegisterSWEntry(boot *BootSW, opts ...SWEntryOption) *SWEntry {
 			entryType:        SWEntryType,
 			entryDescription: "Internal RK entry for swagger UI.",
 			Path:             boot.Path,
-			JsonPath:         boot.JsonPath,
+			JsonPaths:        boot.JsonPaths,
 			Headers:          headers,
 		}
 
@@ -144,7 +144,7 @@ func (entry *SWEntry) MarshalJSON() ([]byte, error) {
 		"name":        entry.GetName(),
 		"type":        entry.GetType(),
 		"description": entry.GetDescription(),
-		"jsonPath":    entry.JsonPath,
+		"jsonPaths":   entry.JsonPaths,
 		"path":        entry.Path,
 		"Headers":     entry.Headers,
 	}
@@ -232,9 +232,11 @@ func (entry *SWEntry) initSwaggerConfig() {
 		Urls: make([]*swUrl, 0),
 	}
 
-	if len(entry.JsonPath) > 0 {
+	if len(entry.JsonPaths) > 0 {
 		// 1: Add user API swagger JSON
-		entry.listFilesWithSuffix(swaggerUrlConfig, entry.JsonPath, false)
+		for _, jsonPath := range entry.JsonPaths {
+			entry.listFilesWithSuffix(swaggerUrlConfig, jsonPath, false)
+		}
 	} else {
 		// try to read from default directories
 		// - docs

--- a/entry/sw_entry.go
+++ b/entry/sw_entry.go
@@ -188,7 +188,7 @@ func (entry *SWEntry) ConfigFileHandler() http.HandlerFunc {
 		case path.Join(entry.Path, "favicon-32x32.png"),
 			path.Join(entry.Path, "favicon-16x16.png"):
 			base := path.Base(p)
-			if file := readFile(filepath.Join("assets/sw/favicon", base), &rkembed.AssetsFS, false); len(file) < 1 {
+			if file := readFile(path.Join("assets/sw/favicon", base), &rkembed.AssetsFS, false); len(file) < 1 {
 				http.Error(writer, "Internal server error", http.StatusInternalServerError)
 			} else {
 				writer.Header().Set("Content-Type", "image/png")
@@ -198,7 +198,7 @@ func (entry *SWEntry) ConfigFileHandler() http.HandlerFunc {
 		case path.Join(entry.Path, "swagger-ui-bundle.js"),
 			path.Join(entry.Path, "swagger-ui-standalone-preset.js"):
 			base := path.Base(p)
-			if file := readFile(filepath.Join("assets/sw/js", base), &rkembed.AssetsFS, false); len(file) < 1 {
+			if file := readFile(path.Join("assets/sw/js", base), &rkembed.AssetsFS, false); len(file) < 1 {
 				http.Error(writer, "Internal server error", http.StatusInternalServerError)
 			} else {
 				writer.Header().Set("Content-Type", "application/javascript")

--- a/entry/sw_entry_test.go
+++ b/entry/sw_entry_test.go
@@ -22,7 +22,7 @@ func TestRegisterSWEntry(t *testing.T) {
 	})
 
 	assert.Equal(t, "/ut-path/", entry.Path)
-	assert.Equal(t, "ut-json-path", entry.JsonPaths)
+	assert.Equal(t, []string{"ut-json-path"}, entry.JsonPaths)
 	assert.Len(t, entry.Headers, 1)
 	assert.NotEmpty(t, entry.GetName())
 	assert.NotEmpty(t, entry.GetType())

--- a/entry/sw_entry_test.go
+++ b/entry/sw_entry_test.go
@@ -15,14 +15,14 @@ import (
 
 func TestRegisterSWEntry(t *testing.T) {
 	entry := RegisterSWEntry(&BootSW{
-		Enabled:  true,
-		Path:     "ut-path",
-		JsonPath: "ut-json-path",
-		Headers:  []string{"a:b"},
+		Enabled:   true,
+		Path:      "ut-path",
+		JsonPaths: []string{"ut-json-path"},
+		Headers:   []string{"a:b"},
 	})
 
 	assert.Equal(t, "/ut-path/", entry.Path)
-	assert.Equal(t, "ut-json-path", entry.JsonPath)
+	assert.Equal(t, "ut-json-path", entry.JsonPaths)
 	assert.Len(t, entry.Headers, 1)
 	assert.NotEmpty(t, entry.GetName())
 	assert.NotEmpty(t, entry.GetType())
@@ -34,10 +34,10 @@ func TestSwEntry_Bootstrap_Interrupt(t *testing.T) {
 	defer assertNotPanic(t)
 
 	entry := RegisterSWEntry(&BootSW{
-		Enabled:  true,
-		Path:     "ut-path",
-		JsonPath: "ut-json-path",
-		Headers:  []string{"a:b"},
+		Enabled:   true,
+		Path:      "ut-path",
+		JsonPaths: []string{"ut-json-path"},
+		Headers:   []string{"a:b"},
 	})
 
 	entry.Bootstrap(context.TODO())
@@ -46,10 +46,10 @@ func TestSwEntry_Bootstrap_Interrupt(t *testing.T) {
 
 func TestSWEntry_UnmarshalJSON(t *testing.T) {
 	entry := RegisterSWEntry(&BootSW{
-		Enabled:  true,
-		Path:     "ut-path",
-		JsonPath: "ut-json-path",
-		Headers:  []string{"a:b"},
+		Enabled:   true,
+		Path:      "ut-path",
+		JsonPaths: []string{"ut-json-path"},
+		Headers:   []string{"a:b"},
 	})
 	assert.Nil(t, entry.UnmarshalJSON(nil))
 }
@@ -57,10 +57,10 @@ func TestSWEntry_UnmarshalJSON(t *testing.T) {
 func TestSWEntry_ConfigFileHandler(t *testing.T) {
 	defer assertNotPanic(t)
 	entry := RegisterSWEntry(&BootSW{
-		Enabled:  true,
-		Path:     "ut-path",
-		JsonPath: "ut-json-path",
-		Headers:  []string{"a:b"},
+		Enabled:   true,
+		Path:      "ut-path",
+		JsonPaths: []string{"ut-json-path"},
+		Headers:   []string{"a:b"},
 	})
 
 	writer := httptest.NewRecorder()


### PR DESCRIPTION
使用buf.work等工具，protobuf按照模块划分文件夹的时候，产生的swagger.json等位于多个文件夹下，需要配置支持多目录读取